### PR TITLE
autotested: Copy known_failures.txt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Latest Documentation
 ======================
 
 For the latest, most up to date documentation please visit
-http://ADEPT.readthedocs.io/en/latest
+http://A-D-E-P-T.readthedocs.io/en/latest
 
 The latest `Docker Autotest`_ documentation is located at:
 http://docker-autotest.readthedocs.io

--- a/kommandir/roles/autotested/files/known_failures.txt
+++ b/kommandir/roles/autotested/files/known_failures.txt
@@ -1,0 +1,1 @@
+# <NVRA> <subtest path> <human-friendly description>

--- a/kommandir/roles/autotested/tasks/setup.yml
+++ b/kommandir/roles/autotested/tasks/setup.yml
@@ -72,6 +72,11 @@
 
 - include: configure_control.yml
 
+- name: Copy 'known_failures.txt' file to config_custom directory
+  copy:
+    dest: "{{ autotest_docker_path }}/config_custom/"
+    src: "known_failures.txt"
+
 - name: Results directory is empty
   file:
   args:


### PR DESCRIPTION
A disposable PR to help test https://github.com/autotest/autotest-docker/pull/761 because I'm lazy and probably screwed up the ``known_failures.txt`` file somehow...