### PR TITLE
known_failures: add fedora atomic one

### DIFF
--- a/kommandir/roles/autotested/files/known_failures.txt
+++ b/kommandir/roles/autotested/files/known_failures.txt
@@ -1,1 +1,2 @@
 # <NVRA> <subtest path> <human-friendly description>
+docker-1.13.1-19.git27e468e.fc26.x86_64		docker_cli/run_volumes/oci_umount	looks like an old version of oci-umount


### PR DESCRIPTION
Looks like an old version of oci-umount bundled with docker

Signed-off-by: Ed Santiago <santiago@redhat.com>