### PR TITLE
Add workaround for OpenStack networking bug

### DIFF
--- a/kommandir/roles/sysconfig_docker/defaults/main.yml
+++ b/kommandir/roles/sysconfig_docker/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+# This is required in some openstack environments and basically harmless in others.
+# RH BZ 1357116
+openstack_mtu_workaround: True

--- a/kommandir/roles/sysconfig_docker/tasks/main.yml
+++ b/kommandir/roles/sysconfig_docker/tasks/main.yml
@@ -25,3 +25,18 @@
     - 'DOCKERDBINARY'
     - 'DOCKER_CONTAINERD_BINARY'
     - 'DOCKER_CONTAINERD_SHIM_BINARY'
+
+- name: OpenStack MTU workaround is enabled for docker and docker-latest
+  lineinfile:
+    dest: "/etc/sysconfig/{{ item }}"
+    backrefs: True
+    # Grab quoting characters, then match only if mtu option NOT present
+    regexp: >
+        ^OPTIONS=(['"])(((?!--mtu=1400).)*)(['"])$
+    line: >
+        OPTIONS=\1\2 --mtu=1400\4
+    create: True  # don't fail play if file doesn't exist (broken in some ansible versions)
+  when: openstack_mtu_workaround | default(False) | bool
+  with_items:
+    - "docker"
+    - "docker-latest"


### PR DESCRIPTION
In the reccomended configuration for OpenStack, some
container-networking opterations can fail due to docker or the kernel
not properly configuring the MTU properly.  This is a long-standing
problem and as of this commit, still being worked on.  As a workaround
for all cases, force the docker and docker-latest MTU size for
containers to 1400 (recommended configuration value).  Add an option
to easily disable this workaround in the future if needed.  Otherwise
leaving this in is basically inconsequential.

Signed-off-by: Chris Evich <cevich@redhat.com>