### PR TITLE
Fix: Kommandir disk space

### DIFF
--- a/exekutir/inventory/group_vars/openstack.yml
+++ b/exekutir/inventory/group_vars/openstack.yml
@@ -34,6 +34,7 @@ cloud_provisioning_command:
         {{ hostvars.exekutir.kommandir_workspace }}/bin/openstack_discover_create.py \
             {{ "--verbose" if adept_debug == True else "" }} \
             {{ "--lockdir=" ~ global_lockdir if global_lockdir|default() not in empty else ""}} \
+            {{ "--userdata=" ~ hostvars.exekutir.workspace ~ "/roles/kommandir_discovered/files/kommandir_userdata.yml" }} \
             {{ kommandir_name }} \
             ssh/exekutir_key.pub
     chdir: "{{ hostvars.exekutir.workspace }}"

--- a/exekutir/roles/kommandir_discovered/files/kommandir_userdata.yml
+++ b/exekutir/roles/kommandir_discovered/files/kommandir_userdata.yml
@@ -1,0 +1,27 @@
+#cloud-config
+
+# Because I'm self-centered
+timezone: US/Eastern
+
+# Don't add silly 'please login as' to .ssh/authorized_keys
+disable_root: false
+
+# Allow password auth in case it's needed
+ssh_pwauth: True
+
+# Import all ssh_authorized_keys (below) into these users
+ssh_import_id: [root]
+
+# public keys to import to users (above)
+# N/B: The value here is assumed to be substituted by
+#      user of this file.
+#      e.g. in python, given strings foo and bar:
+#           foo.format(auth_key_lines=bar)
+ssh_authorized_keys: {auth_key_lines}
+
+# Prevent creating the default, generic user
+users:
+   - name: root
+     primary-group: root
+     homedir: /root
+     system: true


### PR DESCRIPTION
By default, openstack provisioning does not grow the root filesystem.
This is done to allow easier customizing of the layout from w/in
ansible.  However, for the kommandir, all available disk space is
required for jobs.  Drop a custom userdata file, and reference it
from the openstack group variable file.

Signed-off-by: Chris Evich <cevich@redhat.com>