### PR TITLE
Fix kommandir PB ignore $ANSIBLE_PRIVATE_KEY_FILE

### DIFF
--- a/kommandir/roles/common/tasks/main.yml
+++ b/kommandir/roles/common/tasks/main.yml
@@ -9,7 +9,8 @@
         - {}
     hostvarsfile: "{{ inventory_dir }}/host_vars/{{ inventory_hostname }}.yml"
     result:
-    ansible_private_key_file: '{{ hostvars.kommandir.workspace }}/ssh/kommandir_key'
+    # set by job.xn
+    ansible_private_key_file: '{{ lookup("env", "ANSIBLE_PRIVATE_KEY_FILE") }}'
 
 # NO clue why this doesn't get picked up from inventory/group_vars/all.yml
 - name: The no_log_synchronize variable is defined


### PR DESCRIPTION
In some cases, a playbook running on the kommandir may want to use an
alternate private key file.  This is supported by setting the expected
variable in job.xn, for the ansible-playbook command.  However in the
``common`` role, the ``ansible_private_key_file`` fact hard-codes
the value instead of looking it up from the environment.  Fix this.

Signed-off-by: Chris Evich <cevich@redhat.com>