### PR TITLE
Fix: Excluding .git directory during sync

### DIFF
--- a/exekutir/roles/common/tasks/main.yml
+++ b/exekutir/roles/common/tasks/main.yml
@@ -41,7 +41,6 @@
     workspace_rsync_excludes:
         - "--exclude=.ssh"
         - "--exclude=.ansible"
-        - "--exclude=.git"
         - "--exclude=.??*.lock"
         - "--exclude=.*cache"
         - "--exclude=.venv"


### PR DESCRIPTION
This was originally done for security purposes, to block
private hostnames and repo URLs from being accessable on peons
when synchronizing workspace/cache.  However, this is
security-overreach by ADEPT, because it activly removes all choice from
the job author, as to what needs protecting and what doesn't.  In cases
where repository details should not be shared, there are other hooks
for doing this (ex ``extra_exekutir_setup`` and
``extra_kommandir_setup``)

Signed-off-by: Chris Evich <cevich@redhat.com>