### PR TITLE
Fix oversharing of env. vars

### DIFF
--- a/adept.py
+++ b/adept.py
@@ -50,16 +50,11 @@ MYHOSTNAME = gethostname().split('.', 1)[0]
 XTN = 'xn'
 
 # Only pass a certain select set of environment variables through
-# to child processes, for security purposes.  Additional variables
-# can be set by some action items.
+# to child processes automaticly, for security purposes.  Additional
+# variables can be passed using the 'variable' action in the transition
+# file.
 SAFE_ENV_VARS = ('HOME', 'EDITOR', 'TERM', 'PATH', 'PYTHONPATH',
-                 'VIRTUAL_ENV', 'ANSIBLE_CONFIG', 'ANSIBLE_LIBRARY',
-                 'ANSIBLE_INVENTORY', 'SSH_AUTH_SOCK',
-                 'SSH_CONNECTION', 'SSH_TTY', 'TZ', 'USER',
-                 'SHELL', 'ANSIBLE_HOST_KEY_CHECKING',
-                 'ANSIBLE_ROLES_PATH', 'ANSIBLE_PRIVATE_KEY_FILE',
-                 'ANSIBLE_VAULT_PASSWORD_FILE', 'ANSIBLE_FORCE_COLOR',
-                 'DISPLAY_SKIPPED_HOSTS', 'ANSIBLE_HOST_KEY_CHECKING')
+                 'VIRTUAL_ENV', 'TZ', 'USER', 'SHELL')
 # ref: https://github.com/ansible/ansible/blob/devel/lib/ansible/constants.py
 
 def highlight_normal(color_code=32):  # Green

--- a/exekutir.xn
+++ b/exekutir.xn
@@ -1,6 +1,11 @@
 ---
 # vim-syntax: yaml
 
+- variable:
+    name: "ANSIBLE_PRIVATE_KEY_FILE"
+    from_env: "ANSIBLE_PRIVATE_KEY_FILE"
+    default: ""  # One is generated (below) if none set
+
 # Initial workspace configuration
 - command:
     contexts:
@@ -103,6 +108,12 @@
 - variable: {"name":"OS_CLOUD","from_env":"OS_CLOUD","default":""}
 - variable: {"name":"OS_AUTH_URL","from_env":"OS_AUTH_URL","default":""}
 - variable: {"name":"OS_PASSWORD","from_env":"OS_PASSWORD","default":""}
+
+# Support pass-through of Ansible related env. vars
+- variable:
+    name: "ANSIBLE_VAULT_PASSWORD_FILE"
+    from_env: "ANSIBLE_VAULT_PASSWORD_FILE"
+    default: ""
 
 # For all contexts, exit non-zero immediatly on failure.
 # Transition summary:


### PR DESCRIPTION
Originally, ``adept.py`` did not have the ability to allow selecting or
setting env. vars within a transition file.  Therefor the default
set of variables selected for pass-through was quite wide.

Since adding a ``variable`` action-item to the standard, it's now
possible to select env. vars for pass-through and/or set static values.
The more general set of default variables in ``adept.py`` can therefor
be safely paired back to a more sane minimum.  Including only variables
which are extremely common and safe to allow in by default.

Signed-off-by: Chris Evich <cevich@redhat.com>