### PR TITLE
Set OpenStack metadata preserve on create

### DIFF
--- a/.test_openstack_TestDiscoverCreate.test_preserve.json
+++ b/.test_openstack_TestDiscoverCreate.test_preserve.json
@@ -1,0 +1,389 @@
+[
+  {
+    "GET": "http://1.2.3.4/flavors",
+    "response": {
+      "flavors": [
+        {
+          "id": "3",
+          "name": "flavor_name"
+        }
+      ]
+    },
+    "sequence_number": 20,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/v2/images?name=image_name&status=active",
+    "response": {
+      "first": "/v2/images?status=active&name=image_name",
+      "images": [
+        {
+          "id": "the_image_id",
+          "name": "image_name",
+          "status": "active"
+        }
+      ],
+      "schema": "/v2/schemas/images"
+    },
+    "sequence_number": 30,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "547996c1db08",
+          "name": "anotherone"
+        }
+      ]
+    },
+    "sequence_number": 32,
+    "status_code": 200
+  },
+  {
+    "POST": "http://1.2.3.4/servers",
+    "response": {
+      "server": {
+        "id": "102f1788-3b0a-4a37-aecc-547996c1db08"
+      }
+    },
+    "sequence_number": 40,
+    "status_code": 202
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+          "name": "foobar"
+        },
+        {
+          "id": "547996c1db08",
+          "name": "anotherone"
+        }
+      ]
+    },
+    "sequence_number": 42,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/102f1788-3b0a-4a37-aecc-547996c1db08",
+    "response": {
+      "server": {
+        "OS-EXT-STS:power_state": 0,
+        "OS-EXT-STS:vm_state": "building",
+        "addresses": {
+          "network_name": []
+        },
+        "metadata": {
+            "preserve": false
+        },
+        "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "status": "something"
+      }
+    },
+    "sequence_number": 50,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+          "name": "foobar"
+        },
+        {
+          "id": "547996c1db08",
+          "name": "anotherone"
+        }
+      ]
+    },
+    "sequence_number": 52,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/102f1788-3b0a-4a37-aecc-547996c1db08",
+    "response": {
+      "server": {
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "frobnicating",
+        "addresses": {
+          "network_name": []
+        },
+        "metadata": {
+            "preserve": false
+        },
+        "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "status": "something"
+      }
+    },
+    "sequence_number": 60,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+          "name": "foobar"
+        },
+        {
+          "id": "547996c1db08",
+          "name": "anotherone"
+        }
+      ]
+    },
+    "sequence_number": 62,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/102f1788-3b0a-4a37-aecc-547996c1db08",
+    "response": {
+      "server": {
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:1b:51:76",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "5.4.3.2",
+              "version": 4
+            }
+          ]
+        },
+        "metadata": {
+            "preserve": false
+        },
+        "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "status": "ACTIVE"
+      }
+    },
+    "sequence_number": 64,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+          "name": "foobar"
+        },
+        {
+          "id": "547996c1db08",
+          "name": "anotherone"
+        }
+      ]
+    },
+    "sequence_number": 68,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/v2.0/routers",
+    "response": {
+      "routers": [
+        {
+          "admin_state_up": true,
+          "external_gateway_info": {
+            "enable_snat": true,
+            "external_fixed_ips": [
+              {
+                "ip_address": "6.5.4.3",
+                "subnet_id": "the_subnet_id"
+              }
+            ],
+            "network_id": "the_network_id"
+          },
+          "id": "some_number",
+          "name": "network_name",
+          "routes": [],
+          "status": "ACTIVE",
+          "tenant_id": "something"
+        }
+      ]
+    },
+    "sequence_number": 70,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/102f1788-3b0a-4a37-aecc-547996c1db08",
+    "response": {
+      "server": {
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:1b:51:76",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "5.4.3.2",
+              "version": 4
+            }
+          ]
+        },
+        "metadata": {
+            "preserve": false
+        },
+        "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "status": "ACTIVE"
+      }
+    },
+    "sequence_number": 74,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/v2.0/floatingips",
+    "response": {
+      "floatingips": [
+        {
+          "fixed_ip_address": null,
+          "floating_ip_address": "4.5.6.7",
+          "floating_network_id": "the_network_id",
+          "id": "another_floating_id",
+          "port_id": null,
+          "router_id": null,
+          "status": "DOWN"
+        }
+      ]
+    },
+    "sequence_number": 80,
+    "status_code": 200
+  },
+  {
+    "POST": "http://1.2.3.4/servers/102f1788-3b0a-4a37-aecc-547996c1db08/action",
+    "sequence_number": 100,
+    "status_code": 202
+  },
+  {
+    "GET": "http://1.2.3.4/servers/102f1788-3b0a-4a37-aecc-547996c1db08",
+    "response": {
+      "server": {
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:1b:51:76",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "5.4.3.2",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:1b:51:77",
+              "OS-EXT-IPS:type": "floating",
+              "addr": "4.5.6.7",
+              "version": 4
+            }
+          ]
+        },
+        "metadata": {
+            "preserve": false
+        },
+        "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "status": "ACTIVE"
+      }
+    },
+    "sequence_number": 116,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/102f1788-3b0a-4a37-aecc-547996c1db08",
+    "response": {
+      "server": {
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:1b:51:76",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "5.4.3.2",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:1b:51:77",
+              "OS-EXT-IPS:type": "floating",
+              "addr": "4.5.6.7",
+              "version": 4
+            }
+          ]
+        },
+        "metadata": {
+            "preserve": false
+        },
+        "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "status": "ACTIVE"
+      }
+    },
+    "sequence_number": 117,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+          "name": "foobar"
+        },
+        {
+          "id": "547996c1db08",
+          "name": "anotherone"
+        }
+      ]
+    },
+    "sequence_number": 118,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/102f1788-3b0a-4a37-aecc-547996c1db08",
+    "response": {
+      "server": {
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:1b:51:76",
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "5.4.3.2",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:1b:51:77",
+              "OS-EXT-IPS:type": "floating",
+              "addr": "4.5.6.7",
+              "version": 4
+            }
+          ]
+        },
+        "metadata": {
+            "preserve": false
+        },
+        "id": "102f1788-3b0a-4a37-aecc-547996c1db08",
+        "name": "foobar",
+        "os-extended-volumes:volumes_attached": [],
+        "status": "ACTIVE"
+      }
+    },
+    "sequence_number": 120,
+    "status_code": 200
+  }
+]

--- a/.test_openstack_TestReap.test_death.json
+++ b/.test_openstack_TestReap.test_death.json
@@ -1,0 +1,115 @@
+[
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 0,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 5,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+    "response": {
+      "server": {
+        "metadata": { "preserve": "1" },
+        "OS-SRV-USG:launched_at": "2001-01-01T01:01:01.01",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "4.3.2.1",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS:type": "floating",
+              "addr": "6.7.8.9",
+              "version": 4
+            }
+          ]
+        },
+        "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+        "status": "ACTIVE",
+        "name": "foobar"
+      }
+    },
+    "sequence_number": 10,
+    "status_code": 200
+  },
+
+
+
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 15,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+    "response": {
+      "server": {
+        "metadata": { "preserve": "1" },
+        "OS-SRV-USG:launched_at": "2001-01-01T01:01:01.01",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "4.3.2.1",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS:type": "floating",
+              "addr": "6.7.8.9",
+              "version": 4
+            }
+          ]
+        },
+        "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+        "status": "ACTIVE",
+        "name": "foobar"
+      }
+    },
+    "sequence_number": 20,
+    "status_code": 200
+  },
+
+
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+      ]
+    },
+    "sequence_number": 35,
+    "status_code": 200
+  }
+]

--- a/.test_openstack_TestReap.test_forever_bad.json
+++ b/.test_openstack_TestReap.test_forever_bad.json
@@ -1,0 +1,163 @@
+[
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 0,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 5,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+    "response": {
+      "server": {
+        "metadata": { "preserve": "23452345234524352345243523452435243524354235" },
+        "OS-SRV-USG:launched_at": "2001-01-01T01:01:01.01",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "4.3.2.1",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS:type": "floating",
+              "addr": "6.7.8.9",
+              "version": 4
+            }
+          ]
+        },
+        "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+        "status": "ACTIVE",
+        "name": "foobar"
+      }
+    },
+    "sequence_number": 10,
+    "status_code": 200
+  },
+
+
+
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 15,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+    "response": {
+      "server": {
+        "metadata": { "preserve": "23452345234524352345243523452435243524354235" },
+        "OS-SRV-USG:launched_at": "2001-01-01T01:01:01.01",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "4.3.2.1",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS:type": "floating",
+              "addr": "6.7.8.9",
+              "version": 4
+            }
+          ]
+        },
+        "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+        "status": "ACTIVE",
+        "name": "foobar"
+      }
+    },
+    "sequence_number": 20,
+    "status_code": 200
+  },
+
+
+
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 30,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 35,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+    "response": {
+      "server": {
+        "metadata": { "preserve": "23452345234524352345243523452435243524354235" },
+        "OS-SRV-USG:launched_at": "2001-01-01T01:01:01.01",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "4.3.2.1",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS:type": "floating",
+              "addr": "6.7.8.9",
+              "version": 4
+            }
+          ]
+        },
+        "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+        "status": "ACTIVE",
+        "name": "foobar"
+      }
+    },
+    "sequence_number": 40,
+    "status_code": 200
+  }
+]

--- a/.test_openstack_TestReap.test_forever_good.json
+++ b/.test_openstack_TestReap.test_forever_good.json
@@ -1,0 +1,1 @@
+.test_openstack_TestReap.test_verbose.json

--- a/.test_openstack_TestReap.test_verbose.json
+++ b/.test_openstack_TestReap.test_verbose.json
@@ -1,0 +1,163 @@
+[
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 0,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 5,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+    "response": {
+      "server": {
+        "metadata": { "preserve": "-1" },
+        "OS-SRV-USG:launched_at": "2001-01-01T01:01:01.01",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "4.3.2.1",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS:type": "floating",
+              "addr": "6.7.8.9",
+              "version": 4
+            }
+          ]
+        },
+        "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+        "status": "ACTIVE",
+        "name": "foobar"
+      }
+    },
+    "sequence_number": 10,
+    "status_code": 200
+  },
+
+
+
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 15,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+    "response": {
+      "server": {
+        "metadata": { "preserve": "-1" },
+        "OS-SRV-USG:launched_at": "2001-01-01T01:01:01.01",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "4.3.2.1",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS:type": "floating",
+              "addr": "6.7.8.9",
+              "version": 4
+            }
+          ]
+        },
+        "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+        "status": "ACTIVE",
+        "name": "foobar"
+      }
+    },
+    "sequence_number": 20,
+    "status_code": 200
+  },
+
+
+
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 30,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers",
+    "response": {
+      "servers": [
+        {
+          "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+          "name": "foobar"
+        }
+      ]
+    },
+    "sequence_number": 35,
+    "status_code": 200
+  },
+  {
+    "GET": "http://1.2.3.4/servers/8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+    "response": {
+      "server": {
+        "metadata": { "preserve": "-1" },
+        "OS-SRV-USG:launched_at": "2001-01-01T01:01:01.01",
+        "OS-EXT-STS:power_state": 1,
+        "OS-EXT-STS:vm_state": "active",
+        "addresses": {
+          "network_name": [
+            {
+              "OS-EXT-IPS:type": "fixed",
+              "addr": "4.3.2.1",
+              "version": 4
+            },
+            {
+              "OS-EXT-IPS:type": "floating",
+              "addr": "6.7.8.9",
+              "version": 4
+            }
+          ]
+        },
+        "id": "8d36cf2d-de3d-4cc7-9b51-b6bc48cffe06",
+        "status": "ACTIVE",
+        "name": "foobar"
+      }
+    },
+    "sequence_number": 40,
+    "status_code": 200
+  }
+]

--- a/adept.py
+++ b/adept.py
@@ -148,14 +148,15 @@ class Parameters(Sequence):
         if cls._singleton is not None:
             cls._initialized = True
             return cls._singleton
-        else:
-            if source is None:
-                source = cls.default_source
-            # It inherits __new__ from it's ancestors
-            # pylint: disable=E1101
-            cls._singleton = super(Parameters, cls).__new__(cls)
-            return cls._singleton
+        if source is None:
+            source = cls.default_source
+        # It inherits __new__ from it's ancestors
+        # pylint: disable=E1101
+        cls._singleton = super(Parameters, cls).__new__(cls)
+        return cls._singleton
 
+    # There is no sequence __init__, so no super call needed.
+    # pylint: disable=W0231
     def __init__(self, source=None):
         if self._initialized:
             return
@@ -199,14 +200,12 @@ class Parameters(Sequence):
     def __getitem__(self, keyidx):
         if isinstance(keyidx, basestring):
             return getattr(self._data, keyidx)
-        else:
-            return self._data[keyidx]
+        return self._data[keyidx]
 
     def __getattr__(self, key):
         if key in self.FIELDS:
             return self[key]
-        else:
-            return getattr(super(Parameters, self), key)
+        return getattr(super(Parameters, self), key)
 
     @property
     def asdict(self):
@@ -269,8 +268,7 @@ class Parameters(Sequence):
         """
         if filepath == '-':
             return '-'
-        else:
-            return self.mangle_verify(name, os.path.exists, filepath, msgfmt)
+        return self.mangle_verify(name, os.path.exists, filepath, msgfmt)
 
     def verifyxtn(self, name, filepath,
                   msgfmt=("%s Error: %s is not a transition (yaml) file "
@@ -281,11 +279,10 @@ class Parameters(Sequence):
         filepath = self.verifyfile(name, filepath)
         if filepath == '-':
             return '-'
-        else:
-            return self.mangle_verify(name,
-                                      lambda _filepath:
-                                      _filepath.endswith('.%s' % XTN),
-                                      filepath, msgfmt)
+        return self.mangle_verify(name,
+                                  lambda _filepath:
+                                  _filepath.endswith('.%s' % XTN),
+                                  filepath, msgfmt)
 
     def verifystr(self, name, one_word,
                   msgfmt="%s Error: Unacceptable string: '%s'"):
@@ -302,8 +299,7 @@ class Parameters(Sequence):
         test_str = one_word.replace('_', '').replace('-', '')
         if isinstance(one_word, basestring) and test_str.isalnum():
             return one_word
-        else:
-            self.showusage(msgfmt % (name, one_word))
+        return self.showusage(msgfmt % (name, one_word))
 
 
 class ActionBase(object):
@@ -475,8 +471,7 @@ class Command(ActionBase):
                 os.path.normpath(os.path.realpath(fileitem)))
             # N/B Truncates file if exists
             return open(fileitem, "wb")
-        else:
-            return fileitem
+        return fileitem
 
     def init_stdfiles(self, new_env, **dargs):
         """
@@ -602,9 +597,8 @@ class Command(ActionBase):
         except OSError, xcept:
             if xcept.errno != 2:
                 raise
-            else:
-                raise OSError("[Errno 2] No such file or directory: %s"
-                              % self.popen_dargs['executable'])
+            raise OSError("[Errno 2] No such file or directory: %s"
+                          % self.popen_dargs['executable'])
         # No need to display them if they're headed to a file
         if child_proc.stderr or child_proc.stdout:
             sys.stderr.write('stdout/stderr =\n')
@@ -623,9 +617,8 @@ class Command(ActionBase):
             self.exitfile.write(str(returncode))
             sys.stderr.flush()
             return 0
-        else:
-            # Assume exits delt with here (exit with it!)
-            return returncode
+        # Assume exits delt with here (exit with it!)
+        return returncode
 
 
 class Playbook(Command):
@@ -641,10 +634,9 @@ class Playbook(Command):
     inventory = None
 
     def __str__(self, additional=None):
+        mine = {}
         if additional:
             mine = additional
-        else:
-            mine = {}
         for name in ('varsfile', 'limit'):
             thing = getattr(self, name)
             if thing:
@@ -698,15 +690,15 @@ class Playbook(Command):
                              lambda x: True,
                              value, msg_fmt)
 
-            if name is 'inventory':
+            if name == 'inventory':
                 args.extend(['--inventory', value])
                 self.inventory = value
-            elif name is 'config':
+            elif name == 'config':
                 new_env['ANSIBLE_CONFIG'] = value
-            elif name is 'varsfile' and os.path.isfile(value):
+            elif name == 'varsfile' and os.path.isfile(value):
                 args.extend(['--extra-vars', '@%s' % value])
                 self.varsfile = value
-            elif name is 'limit':
+            elif name == 'limit':
                 self.limit = limit
                 args.extend(['--limit', self.limit])
             else:

--- a/kommandir/bin/adept_openstack.py
+++ b/kommandir/bin/adept_openstack.py
@@ -1308,6 +1308,8 @@ if __name__ == '__main__':  # pylint: disable=C0103
     original_environ = os.environ.copy()
     osc = os_client_config.OpenStackConfig()
     clouds = osc.get_cloud_names()
+    if not clouds:
+        clouds = ['default']
     os_cloud_name = original_environ.get('OS_CLOUD', osc.get_cloud_names()[0])
     if os_cloud_name:
         logging.info("Using cloud '%s' from %s", os_cloud_name, osc.config_filename)

--- a/kommandir/bin/flock.py
+++ b/kommandir/bin/flock.py
@@ -62,8 +62,7 @@ class Flock(object):
     def __str__(self):
         if self.is_locked:
             return "Locked (%s)" % self._lockfile.name
-        else:
-            return "Unlocked (%s)" % self._lockfile.name
+        return "Unlocked (%s)" % self._lockfile.name
 
     def __repr__(self):
         return 'Flock(%s)' % self._lockfile.name

--- a/kommandir/bin/openstack_reap.py
+++ b/kommandir/bin/openstack_reap.py
@@ -1,0 +1,1 @@
+adept_openstack.py

--- a/test_adept.py
+++ b/test_adept.py
@@ -286,7 +286,7 @@ class TestPylint(TestCaseBase):
               # --msg-template doesn't work
               #' --msg-template="{msg_id}:{line:3d},{column}: {obj}: {msg}"'
               ' --rcfile="/dev/null"'
-              ' --max-args=6'
+              ' --max-args=8'
               ' --min-public-methods=2'
               ' --no-docstring-rgx="(__.*__)|(_.*)|(__init__)|(__new__)"'
               '')


### PR DESCRIPTION
This is handy for implimenting 'reaper' based cleanup strategy.
Establish a metadata key ``preserve`` for every created server,
with a default value of ``False``.  If a VM needs to be preserved,
then the openstack command or API can be used to easily flip
this key ``True``.

Signed-off-by: Chris Evich <cevich@redhat.com>