### PR TITLE
Switch to using ansible parted module

### DIFF
--- a/kommandir/inventory/group_vars/fedora/storage.yml
+++ b/kommandir/inventory/group_vars/fedora/storage.yml
@@ -2,7 +2,11 @@
 # vim-syntax: yaml
 
 disk_device: "/dev/vdb"
-parted_cmds: "unit % mklabel msdos mkpart primary 0 100 set 1 LVM on"
+parted_opts:
+    device: "/dev/vdb"
+    number: 1
+    state: present
+    flags: [ lvm ]
 
 lvg_ops:
     - vg: docker_vg

--- a/kommandir/inventory/group_vars/rhel/storage.yml
+++ b/kommandir/inventory/group_vars/rhel/storage.yml
@@ -2,7 +2,11 @@
 # vim-syntax: yaml
 
 disk_device: "/dev/vdb"
-parted_cmds: "unit % mklabel msdos mkpart primary 0 100 set 1 LVM on"
+parted_opts:
+    device: "/dev/vdb"
+    number: 1
+    state: present
+    flags: [ lvm ]
 
 lvg_ops:
     - vg: docker_vg

--- a/kommandir/peon_setup.yml
+++ b/kommandir/peon_setup.yml
@@ -53,7 +53,7 @@
     - role: partitioned
       when: not hostvars[inventory_hostname].stone_touched and
             disk_device | default() not in empty and
-            parted_cmds | default() not in empty
+            parted_opts | default() not in empty
 
     - role: rebooted
       reboot_context: "beginning"

--- a/kommandir/roles/partitioned/defaults/main.yml
+++ b/kommandir/roles/partitioned/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+
+# Dictionary of options to pass to the parted Ansible module
+parted_opts:
+
+# Complete path to the disk-device that will be managed
+disk_device:

--- a/kommandir/roles/partitioned/tasks/main.yml
+++ b/kommandir/roles/partitioned/tasks/main.yml
@@ -4,43 +4,47 @@
     that:
         - 'empty is defined'
         - 'disk_device | default() not in empty'
-        - 'parted_cmds | default() not in empty'
-        # No parted on Atomic
+        - 'parted_opts | default() not in empty'
+        # No parted on Atomic, bail out
         - 'is_atomic != True'
 
 - name: State of /root/<disk_device>_partitioned file is known
   stat:
-    path: "/root/{{ disk_device }}_partitioned"
+    path: "/root/{{ disk_device | basename }}_partitioned"
   register: result
-
-- name: File does exist
-  set_fact:
-    result: True
-  when: result.stat is defined and
-        result.stat.exists is defined and
-        result.stat.exists == True
-
-- name: File does not exist
-  set_fact:
-    result: False
-  when: result != True
 
 - name: Key variables are displayed
   debug:
     var: "{{ item }}"
-  with_items: ["disk_device","parted_cmds"]
+  with_items: ["result", "disk_device","parted_opts"]
   when: adept_debug
 
 - block:
 
-    - name: parted command is executed
-      shell: "/usr/sbin/parted --align optimal --script {{ disk_device }} {{ parted_cmds }}"
-
-    - name: Final partition table is stored
-      shell: "/usr/sbin/sfdisk --dump {{ disk_device }} > /root/{{ disk_device | basename }}_partitioned"
+    - name: Partition table is updated
+      parted:
+        align: '{{ parted_opts.align | default(omit) }}'
+        device: '{{ disk_device }}'
+        flags: '{{ parted_opts.flags | default(omit) }}'
+        label: '{{ parted_opts.label | default(omit) }}'
+        name: '{{ parted_opts.name | default(omit) }}'
+        number: '{{ parted_opts.number | default(omit) }}'
+        part_end: '{{ parted_opts.part_end | default(omit) }}'
+        part_start: '{{ parted_opts.part_start | default(omit) }}'
+        part_type: '{{ parted_opts.part_type | default(omit) }}'
+        state: '{{ parted_opts.state | default(omit) }}'
+        unit: '{{ parted_opts.unit | default(omit) }}'
 
     - name: system needs reboot when partition table changed
       set_fact:
         needs_reboot: True
 
-  when: result != True  # file didn't exist
+  always:
+
+    - name: Drop /root/<disk_device>_partitioned file to avoid re-partitioning on accident
+      file:
+        path: "/root/{{ disk_device | basename }}_partitioned"
+        state: touch
+
+  when: result.stat is undefined or
+        not result.stat.exists | bool


### PR DESCRIPTION
Previously this was quite buggy/unreliable, so to avoid messing up
disks, we just fed in the command-line directly.  Now the module seems
more mature, and using it should be far more stable/standard that doing
anything custom.

Signed-off-by: Chris Evich <cevich@redhat.com>