### PR TITLE
Fix running setup more than once

### DIFF
--- a/exekutir/roles/exekutir_workspace_setup/tasks/main.yml
+++ b/exekutir/roles/exekutir_workspace_setup/tasks/main.yml
@@ -50,9 +50,10 @@
 - name: Contents of exekutir's results directory moved to kommandir's
   synchronize:
     archive: True
-    src: '{{ workspace }}/results'
-    dest: "{{ kommandir_workspace }}"
-  when: (workspace ~ "/results") | is_dir
+    src: '{{ workspace }}/results/'
+    dest: "{{ kommandir_workspace }}/results/"
+  when: (workspace ~ "/results") | is_dir and
+        not (workspace ~ "/results") | is_link
 
 - name: exekutir's results directory is absent prior to linking
   file:

--- a/kommandir/inventory/group_vars/openstack/creation_destruction.yml
+++ b/kommandir/inventory/group_vars/openstack/creation_destruction.yml
@@ -38,7 +38,7 @@ cloud_asserts:
 
 cloud_provisioning_command:
     command: >
-        bin/openstack_exclusive_create.py \
+        bin/openstack_discover_create.py \
             {{ "--verbose" if adept_debug == True else "" }} \
             {{ "--lockdir=" ~ hostvars.kommandir.global_lockdir | trim if hostvars.kommandir.global_lockdir|default() not in empty else ""}} \
             --image {{ peon_image | trim }} \


### PR DESCRIPTION
ADEPT's setup should behave idempotently, meaning contexts can be
applied more than once.  A bug in the exekutir_workspace_setup role
relating to pre-existing results was preventing this.  Also,
the default openstack provisioning command was configured to
fail if a peon already existed.  Change this to be more tolerant
of existing peons.

Signed-off-by: Chris Evich <cevich@redhat.com>