### PR TITLE
Fix peon_up again: No python on Fedora

### DIFF
--- a/kommandir/roles/peon_up/defaults/main.yml
+++ b/kommandir/roles/peon_up/defaults/main.yml
@@ -6,3 +6,6 @@ wait_for_timeout: 13
 
 # When empty, do not include application of failed_peon_result role
 reboot_context:
+
+# The raw command to execute on the remote host
+up_cmd: '/bin/true'

--- a/kommandir/roles/peon_up/tasks/main.yml
+++ b/kommandir/roles/peon_up/tasks/main.yml
@@ -35,11 +35,9 @@
   retries: '{{ wait_for_timeout }}'
   delay: 1
 
-# Any remote module that fails will immediatly cause host to be marked uncreachable
-# after zero retries.  Run a local shell command to do the detection, with retries,
-# until it's successful.
-- name: The ansible ping module runs successfully against host
-  command: '{{ adept_path }}/venv-cmd.sh ansible -i inventory {{ inventory_hostname }} -m ping'
+# It's undesireable to have the host removed from inventory while it's still booting up.
+- name: The ansible raw module runs successfully on host
+  command: '{{ adept_path }}/venv-cmd.sh ansible -i inventory {{ inventory_hostname }} -m raw -a "{{ up_cmd }}"'
   register: result
   delegate_to: kommandir
   until: result | success


### PR DESCRIPTION
The 'ping' module requires python on the remote host.  Instead, use the
raw module to run /bin/true.  The python requirement is handled later in
another playbook.

Signed-off-by: Chris Evich <cevich@redhat.com>