### PR TITLE
Update to venv-cmd.sh from crap fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
         - PATH="$PATH:$VIRTUAL_ENV/bin"
 
 install:
+    - sudo apt-get -qq update
+    - sudo apt-get -qq install realpath
     # These seem to match up roughly with behavior on RHEL 7
     - pip install Sphinx==1.2.2 unittest2==1.1.0 pylint==1.4.5 virtualenv==15.1.0
     - pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,23 @@
 # N/B: Hashes are required here | versions frozen for stability
 
-ansible==2.4.1.0 --hash=sha256:da61afb29cc5bd6bc4737a2da06e673fb6fccc3ae2685130d19ab3a8e404fb6a
-
-ansible-lint==3.4.17 --hash=sha256:9cebc110019f52a7dd66cb785d99d43b556f246c3046661b00c7bcfe74a9504d
+ansible==2.4.2.0 --hash=sha256:315f1580b20bbc2c2f1104f8b5e548c6b4cac943b88711639c5e0d4dfc4d7658
 
 asn1crypto==0.23.0 --hash=sha256:654b7db3b120e23474e9a1e5e38d268c77e58a9e17d2cb595456c37309846494
 
 bcrypt==3.1.4 --hash=sha256:a005ed6163490988711ff732386b08effcbf8df62ae93dd1e5bda0714fad8afb \
               --hash=sha256:2788c32673a2ad0062bea850ab73cffc0dba874db10d7a3682b6f2f280553f20 \
-              --hash=sha256:49e96267cd9be55a349fd74f9852eb9ae2c427cd7f6455d0f1765d7332292832
+              --hash=sha256:49e96267cd9be55a349fd74f9852eb9ae2c427cd7f6455d0f1765d7332292832 \
+              --hash=sha256:ae35dbcb6b011af6c840893b32399252d81ff57d52c13e12422e16b5fea1d0fb
 
 cffi==1.11.2 --hash=sha256:89829f5cfbcb5ad568a3d61bd23a8e33ad69b488d8f6a385e0097a4c20742a9b \
              --hash=sha256:d7461ef8671ae40f991384bbc4a6b1b79f4e7175d8052584be44041996f46517 \
-             --hash=sha256:5f96c92d5f5713ccb71e76dfa14cf819c59ecb9778e94bcb541e13e6d96d1ce5
+             --hash=sha256:5f96c92d5f5713ccb71e76dfa14cf819c59ecb9778e94bcb541e13e6d96d1ce5 \
+             --hash=sha256:062c66dabc3faf8e0db1ca09a6b8e308846e5d35f43bed1a68c492b0d96ac171
 
 cryptography==2.1.3 --hash=sha256:35eb35340fdc0b772301f9de985db8d732f3c79dbd647d06b9a8e4e111b53950 \
                     --hash=sha256:1fc1c6ad9f04871399de407a4f0f555adba5c7ec68068fd27d7ceee9e493755c \
-                    --hash=sha256:2d72c8cd1e2be9942052b85b1481c74b2eb36780889696ce66afe602c04b9c67
+                    --hash=sha256:2d72c8cd1e2be9942052b85b1481c74b2eb36780889696ce66afe602c04b9c67 \
+                    --hash=sha256:791e228b5df8f124bfa33384195864cb9f5420b619580258d9002f14e625312e
 
 enum34==1.1.6 --hash=sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a \
               --hash=sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79
@@ -40,16 +41,18 @@ pycrypto==2.6.1 --hash=sha256:f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92
 
 PyNaCl==1.2.0 --hash=sha256:8e194ea19c447c4caa94a84316412ad11cfb61f029d408fd4bdc1164ec694578 \
               --hash=sha256:b83e4232b43a52c8802234d575f992f82c1e9c466acd911983613a3823c4dc4e \
-              --hash=sha256:189410422028e7b0543dee6aca3da026bbd66bbad078143c46c5a3faf2733acb
+              --hash=sha256:189410422028e7b0543dee6aca3da026bbd66bbad078143c46c5a3faf2733acb \
+              --hash=sha256:77c3b6d6fbf8b2137d41be9aed9eff30232287aeba00a6d353aa48fc9de4c55e
 
 PyYAML==3.12 --hash=sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab
+
+pip==9.0.1 --hash=sha256:690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0
 
 six==1.11.0 --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb
 
 virtualenv==15.1.0 --hash=sha256:39d88b533b422825d644087a21e78c45cf5af0ef7a99a1fc9fbb7b481e5c85b0
 
-pip==9.0.1 --hash=sha256:690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0
-
-virtualenv==15.1.0 --hash=sha256:39d88b533b422825d644087a21e78c45cf5af0ef7a99a1fc9fbb7b481e5c85b0
-
-pip==9.0.1 --hash=sha256:690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0
+# Shave a tiny amount (seconds) off of the install time
+# by using pre-built binaries.
+--only-binary ':all:'
+--no-binary 'ansible,MarkupSafe,pycparser,pycrypto,PyYAML'

--- a/venv-cmd.sh
+++ b/venv-cmd.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 
 # This wrapper-script reduces the number of python-dependencies needed to execute a command
-# and always executes from a fixed-version / verified environment. It only requires
-# the following (or equivilent) be installed:
+# and always executes from a fixed-version / verified environment. This means, no matter
+# what happens on the host package-wise, the nested command should behave in a very predictable
+# way (including, known bugs).  The last part is important, because bugs can be worked around
+# easier than unpredictable code-changes.
 #
-#    python2-virtualenv gcc openssl-devel redhat-rpm-config libffi-devel
-#    python-devel python3-pycurl python-pycurl python2-simplejson util-linux
+# It only requires the following (or equivalent) be installed for all platforms (unless I missed one):
 #
-# Example usage (where ansible is NOT already installed)
+#    python3 python3-devel python34 python34-devel python2-virtualenv gcc
+#    openssl-devel redhat-rpm-config libffi-devel python-devel python3-pycurl
+#    python-pycurl python2-simplejson util-linux
 #
-#   $ ./venv-cmd ansible-playbook --version
+# Example usage:
+#
+#   $ ./bin/venv-cmd ansible-playbook --version
 #
 # N/B: You may set $WORKSPACE and/or $ARTIFACTS to control where things are written
 
@@ -17,7 +22,6 @@
 set -e
 
 echo
-
 if [ "$#" -lt "1" ]
 then
     echo "No command and command-line options specified."
@@ -25,34 +29,86 @@ then
     exit 3
 fi
 
+if [[ "${DEBUG:-false}" == "true" ]]
+then
+    set -x
+else
+    set +x
+fi
+
+# Don't leave __pycache__ directories everywhere
+PYTHONDONTWRITEBYTECODE="true"
+PYTHON3SUPPORT="${PYTHON3SUPPORT:-false}"  # Only required for CI/Unittesting
 VENV_DIRNAME=".venv"
 LOCKTIMEOUT_MINUTES="10"
 SCRIPT_NAME=$(basename "$0")
-SCRIPT_DIR=$(dirname `readlink -f "$0"`)
-[ -n "$WORKSPACE" ] || export WORKSPACE="$SCRIPT_DIR"
-export WORKSPACE=$(readlink -f $WORKSPACE)
-mkdir -p "$WORKSPACE"
-REQUIREMENTS="$WORKSPACE/requirements.txt"
+SCRIPT_DIR=$(dirname `realpath "$0"`)
+REPO_DIR=$(realpath "$SCRIPT_DIR")
 
-# Confine this w/in the workspace
+export WORKSPACE="${WORKSPACE:-$REPO_DIR}"
+export WORKSPACE=$(realpath $WORKSPACE)
 export PIPCACHE="$WORKSPACE/.cache/pip"
-mkdir -p "$PIPCACHE"
-# Don't recycle cache or bootstrap venv unless it succeeds
-trap 'rm -rf "$PIPCACHE" "$WORKSPACE/.venvbootstrap"' EXIT
+MARKERFILE="$WORKSPACE/$VENV_DIRNAME/.complete"
 
-ARTIFACTS="${ARTIFACTS:-$WORKSPACE/kommandir_workspace/results}"
-export ARTIFACTS
+export ARTIFACTS="${ARTIFACTS:-$WORKSPACE/artifacts}"
+export ARTIFACTS=$(realpath "$ARTIFACTS")
 mkdir -p "$ARTIFACTS"
 export LOGFILEPATH="$ARTIFACTS/$SCRIPT_NAME.log"
 
+REQUIREMENTS="$REPO_DIR/requirements.txt"
+# Boot-strap requirements are very minimal
+BSREQ="$(mktemp -p "" $(basename $0)_XXXX)"
+cat << EOF > "$BSREQ"
+pip==9.0.1 --hash=sha256:690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0
+virtualenv==15.1.0 --hash=sha256:39d88b533b422825d644087a21e78c45cf5af0ef7a99a1fc9fbb7b481e5c85b0
+EOF
+
+# (Line-delineated)
+CLEANUP_PATHS="$BSREQ
+               $PIPCACHE
+               $WORKSPACE/${VENV_DIRNAME}bootstrap
+               $WORKSPACE/${VENV_DIRNAME}"
+
+cd "$WORKSPACE"
+
+cleanup() {
+    RET2="$?"  # prior exit code
+    set +x
+    set -e
+    echo "$CLEANUP_PATHS" |
+    while read LINE
+    do
+        rm -rf "$LINE"
+    done
+    if [ "${RET2:-1}" -ne "0" ]
+    then
+        echo "Exiting: $RET2"
+        exit $RET2
+    fi
+}
+
+handle_log_and_cleanup() {
+    RET="$?"  # prior exit code
+    set +x
+    set -e
+    cleanup
+    if [ "${RET:-2}" -ne "0" ]
+    then
+        echo "An error ($RET) occurred, displaying log contents:"
+        cat "$LOGFILEPATH"
+        exit ${RET:-3}
+    fi
+}
+trap handle_log_and_cleanup EXIT
+
 # All command failures from now on are fatal
-set -e
 echo "Bootstrapping trusted virtual environment, this may take a few minutes, depending on networking."
 echo
 echo "-----> Log: \"$LOGFILEPATH\")"
 echo
 
 (
+  set -e
   if ! flock --nonblock 42
   then
       echo "Another $SCRIPT_NAME virtual environment creation process is running."
@@ -67,47 +123,66 @@ echo
   fi
   echo "Virtual environment creation lock acquired"
   echo
+  set -ex
   (
-    set -x
-    cd "$WORKSPACE"
     # When running more than once, make it fast by skipping the bootstrap
-    if [ ! -d "./.venv" ] || [ ! -r "./.venv/.complete" ]; then
+    if [ ! -d "./$VENV_DIRNAME" ] || [ ! -r "$MARKERFILE" ]
+    then  # Don't allow previously broken cache to break fresh setup
+        echo "Setting up a new virtual environment"
+        rm -rf "$PIPCACHE"
+        rm -rf "$VENV_DIRNAME"
         # N/B: local system's virtualenv binary - uncontrolled version fixed below
-        virtualenv --no-site-packages --python=python2.7 ./.venvbootstrap
-        # Set up paths to install/operate out of $WORKSPACE/.venvbootstrap
-        source ./.venvbootstrap/bin/activate
+        virtualenv --python=python2 "./${VENV_DIRNAME}bootstrap"
+        python3 -m venv "./${VENV_DIRNAME}bootstrap"
+        # Set up paths to install/operate out of $WORKSPACE/${VENV_DIRNAME}bootstrap
+        source "./${VENV_DIRNAME}bootstrap/bin/activate"
         # N/B: local system's pip binary - uncontrolled version fixed below
         # pip may not support --cache-dir, force it's location into $WORKSPACE the ugly-way
         OLD_HOME="$HOME"
         export HOME="$WORKSPACE"
+        # Newer pip required to support hash-checking
         pip install --force-reinstall --upgrade pip==9.0.1
         # Undo --cache-dir workaround
         export HOME="$OLD_HOME"
-        # Install fixed, trusted, hashed versions of all requirements (including pip and virtualenv)
-        pip --cache-dir="$PIPCACHE" install --force-reinstall --require-hashes \
-            --requirement "$SCRIPT_DIR/requirements.txt"
-        # Setup trusted virtualenv using hashed packages from requirements.txt
-        ./.venvbootstrap/bin/virtualenv --no-site-packages --python=python2.7 "./$VENV_DIRNAME"
-        # Exit untrusted virtualenv
-        deactivate
-        rm -rf ./.venvbootstrap  # No longer needed
+        # Install fixed, trusted, hashed versions of pip and virtualenv
+        ARGS="--cache-dir="$PIPCACHE" install --force-reinstall --require-hashes --isolated --requirement"
+        pip $ARGS "$BSREQ"
+        [ "$PYTHON3SUPPORT" == 'false' ] || \
+            python3 -m pip $ARGS "$BSREQ"
+        # Setup trusted virtualenv using hashed packages from $REQUIREMENTS
+        [ "$PYTHON3SUPPORT" == 'false' ] || \
+            "./${VENV_DIRNAME}bootstrap/bin/python3" -m venv "./$VENV_DIRNAME"
+        "./${VENV_DIRNAME}bootstrap/bin/virtualenv" --python=python2 "./$VENV_DIRNAME"
+    else
+        echo "Using existing virtual environment"
     fi
-    # Enter trusted virtualenv
-    source ./.venv/bin/activate
-    # Upgrade stock-pip to support hashes
-    ./.venv/bin/pip install --force-reinstall --cache-dir="$PIPCACHE" --upgrade pip==9.0.1
-    # Re-install from cache but validate all hashes (including on pip itself)
-    ./.venv/bin/pip --cache-dir="$PIPCACHE" install --require-hashes \
-        --requirement "$SCRIPT_DIR/requirements.txt"
-    [ -r "./.venv/.complete" ] || echo "Setup by: $@" > "./.venv/.complete"
+    echo "$@" > "$MARKERFILE"  # $VENV_DIRNAME and $PIPCACHE are now trusted
+
+    # Enter trusted virtualenv with trusted cache
+    source "./$VENV_DIRNAME/bin/activate"
+    # Install actual reqirements
+    ARGS="--cache-dir="$PIPCACHE" install --require-hashes --isolated --requirement"
+    pip $ARGS "$REQUIREMENTS"
+    [ "$PYTHON3SUPPORT" == 'false' ] || \
+        python3 -m pip $ARGS "$REQUIREMENTS"
   ) &>> "$LOGFILEPATH"
 ) 42>>"$LOGFILEPATH"
 
-# Success, clear cache-destruction on exit
-trap EXIT
+# Since setup is complete, preserve environment and cache on exit
+CLEANUP_PATHS="$BSREQ
+$WORKSPACE/${VENV_DIRNAME}bootstrap"
+trap cleanup EXIT
 
-# Enter trusted virtualenv in this shell
-source "$WORKSPACE/$VENV_DIRNAME/bin/activate"
+source "./$VENV_DIRNAME/bin/activate"
+
+if [[ -r "./requirements.yml" ]] && [[ ! -r "./galaxy_roles/.installed" ]]
+then
+    echo "Installing Ansible-Galaxy Roles from requirements.yml"
+    mkdir -p ./galaxy_roles
+    ansible-galaxy install --roles-path="./galaxy_roles" --role-file="./requirements.yml"
+    touch "./galaxy_roles/.installed"
+fi
+
 echo "Executing $@"
 echo
 "$@"


### PR DESCRIPTION
It's a bit faster due to using some pre-build binaries.  However the big
win is it's error-handling of the logfile when something goes wrong.  It
also adds (optional) python3 support.

Signed-off-by: Chris Evich <cevich@redhat.com>