### PR TITLE
Add temporary podman job and supporting changes

### DIFF
--- a/.travis_typo_check.sh
+++ b/.travis_typo_check.sh
@@ -20,10 +20,6 @@ then
     exit 3
 fi
 
-# The TYPOS value was formerly specified in .travis.yml
-# TODO: Remove this workaround in another/later PR
-sed -i -r -e '/^-        - TYPOS=/d' /tmp/commits_with_diffs
-
 echo "Examining $LINES change lines for typos:"
 egrep -a -i -2 --color=always "$TYPOS" /tmp/commits_with_diffs && exit 3
 

--- a/jobs/basic/README
+++ b/jobs/basic/README
@@ -1,7 +1,8 @@
 {# This is a jinja2 template rendered into the artifacts directory #}
 
-The {{ job_name }} job is intended to exercise Docker with a small subset
-of tests.  It uses an "all-defaults" peon and Docker Autotest configuration.
+The {{ job_name }} job uses a small subset of tests to exercize
+{{ "docker" if not job_name | search("podman") else "podman" }}
+It uses an "all-defaults" RHEL peon and Docker Autotest configuration.
 
 Docker Autotest results for each peon are located under subdirectories of
 this `results` directory (by inventory-name).  Also there are

--- a/jobs/basic/roles/autotest_installed/tasks/main.yml
+++ b/jobs/basic/roles/autotest_installed/tasks/main.yml
@@ -13,6 +13,7 @@
     perms: True
     recursive: True
     src: '{{ item.src }}'
+  when: item.src | is_dir
   with_items:
     - src: 'cache/autotest/'
       dst: '{{ destdir }}/'

--- a/jobs/podman_basic/README
+++ b/jobs/podman_basic/README
@@ -1,0 +1,1 @@
+../basic/README

--- a/jobs/podman_basic/inventory/hosts.yml
+++ b/jobs/podman_basic/inventory/hosts.yml
@@ -1,46 +1,38 @@
 ---
 
-# Format Ref: https://docs.ansible.com/ansible/devel/plugins/inventory/yaml.html
-
 all:
     hosts:
         rhel-latest:
             peon_groups:
-                # Allows switching clouds.  Default: peon_cloud_group=openstack
                 - "{{ hostvars.kommandir.peon_cloud_group | mandatory }}"
-                # Generic OS group, interacts with cloud_group (above)
                 - rhel
-                # OS Specialization group, interacts with topic group (below)
-                - latest_rhel
-                # Topic-group, the main purpose for the job
+                - latest_rhel_copr
                 - autotested
 
     children:
-        # Group of hosts which are to be provisioned/managed by ADEPT
         peons:
             hosts:
                 rhel-latest
 
-        # OS Specialization group
-        latest_rhel:
+        latest_rhel_copr:
             vars:
-                # No subscription necessary, "latest" cooked into image
                 rhsm: {}
-                # OpenStack *-latest images include 'compose.repo', use that.
                 disable_all_rh_repos: True  # subscription-manager repos
-                # 'compose.repo' doesn't include extras, use the latest
-                yum_repos: '{{ [_private_latest_extras_yum_repo]
-                               if _private_latest_extras_yum_repo is defined
-                               else [] }}'
+                yum_repos:
+                    - '{{ _private_latest_extras_yum_repo | default({}) }}'
+                    - name: "baude-Upstream_CRIO_Family"
+                      description: "Copr repo for Upstream_CRIO_Family owned by baude"
+                      baseurl: "https://copr-be.cloud.fedoraproject.org/results/baude/Upstream_CRIO_Family/epel-7-x86_64/"
+                      gpgkey: "https://copr-be.cloud.fedoraproject.org/results/baude/Upstream_CRIO_Family/pubkey.gpg"
+                      gpgcheck: True
 
-                enable_repos:  # These and only these, already cooked into image
+                enable_repos:
                     - base
                     - optional
                     - '{{ "latest-extras"
                           if _private_latest_extras_yum_repo is defined
                           else "optional" }}'  # can't use `omit` here.
-
-                # Low-level rpms to install
+                    - baude-Upstream_CRIO_Family
                 install_rpms:
                     - bridge-utils
                     - bzip2
@@ -57,15 +49,8 @@ all:
                     - tar
                     - which
 
-        # Topic-group
         autotested:
             vars:
                 # No mail sent when empty
                 notification_email: '{{ _private_notification_email | default("") }}'
                 notification_url: '{{ _private_notification_url | default("") }}'
-                autotest_rpm_deps:
-                    - atomic
-                    - docker
-                    - docker-latest
-                    - docker-selinux
-                    - runc

--- a/jobs/podman_basic/kommandir_vars.yml
+++ b/jobs/podman_basic/kommandir_vars.yml
@@ -1,0 +1,14 @@
+---
+
+# List of dictionaries, with options to the git ansible module.
+git_cache_args:
+    - repo: "https://github.com/autotest/autotest.git"
+      recursive: False
+      depth: 3
+      cachepath: 'autotest'
+      force: True
+    - repo: "https://github.com/autotest/autotest-docker.git"
+      version: "podman"
+      recursive: False
+      cachepath: 'autotest-podman'
+      force: True

--- a/jobs/podman_basic/roles/autotest_executed/defaults/main.yml
+++ b/jobs/podman_basic/roles/autotest_executed/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+
+# Name for results sub-directory
+podman_autotest_tag: default
+
+podman_autotest_timeout: 30  # minutes
+
+# When non-empty, e-mail address to send report to
+notification_email:
+
+# When non-empty, reference URL for e-mail, where result files persist
+notification_url:

--- a/jobs/podman_basic/roles/autotest_executed/meta/main.yml
+++ b/jobs/podman_basic/roles/autotest_executed/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+    - role: failed_peon_result
+      this_role: "autotest_executed"

--- a/jobs/podman_basic/roles/autotest_executed/tasks/main.yml
+++ b/jobs/podman_basic/roles/autotest_executed/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+
+- name: Execute Podman Autotest
+  command: ./autotest-local "--tag={{ podman_autotest_tag }}" run podman
+  args:
+    chdir: /var/lib/autotest/client
+    creates: "{{ results_src_dirpath }}/status"
+  async: '{{ podman_autotest_timeout | int * 60 }}'
+
+# TODO: Make this work if jUnit results are needed
+# - name: Results are converted into junit format
+#   command: tests/podman/results2junit "--name={{ inventory_hostname }}" "{{ results_src_dirpath }}"
+#   args:
+#     chdir: /var/lib/autotest/client
+#     creates: "{{ results_src_dirpath }}/results.junit"
+
+- name: Results are synchronized down to kommandir workspace
+  synchronize:
+    checksum: True
+    delete: True
+    dest: "{{ results_dst_dirpath }}/"
+    mode: "pull"
+    recursive: True
+    src: "{{ results_src_dirpath }}/"
+
+- name: Results are processed into human-readable text-table for e-mail
+  shell: 'tools/scan_results.py "{{ results_src_dirpath }}/status" | sed "s/GOOD/PASS/g"'
+  args:
+    chdir: /var/lib/autotest/client
+  register: result
+
+- name: Humans are notified by e-mail of autotest results
+  mail:
+    host: smtp.redhat.com
+    secure: try
+    to: '{{ notification_email }}'
+    from: 'nobody@redhat.com'
+    subject: "[ADEPT Results] Job {{ uuid }} completed on {{ inventory_hostname }}"
+    body: |
+        Key RPMs:
+        ----------
+        {{ lookup("pipe","cat " ~ key_rpms_filepath) }}
+
+        Autotest Results:
+        -----------------
+        {{ result.stdout }}
+
+        {% if notification_url | default("", True) | trim | length %}
+        Artifacts: {{ notification_url }}
+        {% endif %}
+  when: notification_email | default("", True) | trim | length

--- a/jobs/podman_basic/roles/autotest_executed/vars/main.yml
+++ b/jobs/podman_basic/roles/autotest_executed/vars/main.yml
@@ -1,0 +1,5 @@
+---
+
+results_src_dirpath: "/var/lib/autotest/client/results/{{ podman_autotest_tag }}"
+results_dst_dirpath: "{{ hostvars.kommandir.workspace }}/results/{{ inventory_hostname }}/{{ podman_autotest_tag }}"
+key_rpms_filepath: "{{ results_dst_dirpath }}/sysinfo/key_rpms"

--- a/jobs/podman_basic/roles/has_swap/defaults/main.yml
+++ b/jobs/podman_basic/roles/has_swap/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+swap_file_path: /var/swapfile
+swap_file_size_gb: 4

--- a/jobs/podman_basic/roles/has_swap/tasks/main.yml
+++ b/jobs/podman_basic/roles/has_swap/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+
+- name: Create swap file
+  command: dd if=/dev/zero of={{ swap_file_path }} bs=1024 count={{ swap_file_size_gb }}M
+           creates="{{ swap_file_path }}"
+  tags:
+    - swap.file.create
+
+- name: Change swap file permissions
+  file: path="{{ swap_file_path }}"
+        owner=root
+        group=root
+        mode=0600
+  tags:
+    - swap.file.permissions
+
+- name: "Check swap file type"
+  command: file {{ swap_file_path }}
+  register: swapfile
+  tags:
+    - swap.file.mkswap
+
+- name: Make swap file
+  command: "mkswap {{ swap_file_path }}"
+  when: swapfile.stdout.find('swap file') == -1
+  tags:
+    - swap.file.mkswap
+
+- name: Write swap entry in fstab
+  mount: name=none
+         src={{ swap_file_path }}
+         fstype=swap
+         opts=sw
+         passno=0
+         dump=0
+         state=present
+  tags:
+    - swap.fstab
+
+- name: Point-in-time ansible_swaptotal_mb value is obtained
+  setup:
+    gather_subset: hardware
+
+- name: Mount swap
+  command: "swapon {{ swap_file_path }}"
+  when: ansible_swaptotal_mb < 1
+  tags:
+    - swap.file.swapon

--- a/jobs/podman_basic/roles/podman_autotest/defaults/main.yml
+++ b/jobs/podman_basic/roles/podman_autotest/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+autotest_rpm_deps: [ "podman", ]

--- a/jobs/podman_basic/roles/podman_autotest/meta/main.yml
+++ b/jobs/podman_basic/roles/podman_autotest/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+    - role: failed_peon_result
+      this_role: "podman_autotest"

--- a/jobs/podman_basic/roles/podman_autotest/tasks/main.yml
+++ b/jobs/podman_basic/roles/podman_autotest/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+
+- name: install rpms needed for autotest
+  package:
+    name: '{{ item }}'
+    state: present
+  with_items: "{{ autotest_rpm_deps }}"
+
+- name: Docker is NOT installed directly, or by dependency resolution.
+  package:
+    name: docker-client
+    state: absent
+
+- name: install autotest, podman-autotest
+  synchronize:
+    delete: True  # Clobber whatever happens to already be there
+    dest: "{{ item.dst }}"
+    links: True
+    perms: True
+    recursive: True
+    src: '{{ item.src }}'
+  when: item.src | is_dir
+  with_items:
+    - src: 'cache/autotest/'
+      dst: '{{ destdir }}/'
+
+    - src: 'cache/autotest-podman/'
+      dst: '{{ destdir }}/client/tests/podman/'
+
+- name: Avoid docker-autotest changes by using filter for podman output
+  file:
+    src: "{{ output_filter_path }}"
+    dest: "/usr/bin/docker"
+    state: link
+
+- name: Fix podman_output_filter selinux type
+  sefcontext:
+    setype: container_runtime_exec_t
+    target: "{{ output_filter_path }}"
+
+- name: Running systemd inside a container is permitted
+  seboolean:
+    name: container_manage_cgroup
+    state: True
+    persistent: True

--- a/jobs/podman_basic/roles/podman_autotest/vars/main.yml
+++ b/jobs/podman_basic/roles/podman_autotest/vars/main.yml
@@ -1,0 +1,4 @@
+---
+
+destdir: "/var/lib/autotest"
+output_filter_path: "{{ destdir }}/client/tests/podman/podman_filter"

--- a/jobs/podman_basic/run.yml
+++ b/jobs/podman_basic/run.yml
@@ -1,0 +1,1 @@
+../basic/run.yml

--- a/jobs/podman_basic/setup.yml
+++ b/jobs/podman_basic/setup.yml
@@ -1,0 +1,11 @@
+---
+
+- include: default_setup.yml
+
+- hosts: peons
+  vars_files:
+      - kommandir_vars.yml
+  roles:
+    - podman_autotest
+    - has_swap
+    - success_peon_result


### PR DESCRIPTION
Supporting changes needed to help share bunches of common elements between the 'basic' job and the new 'podman_basic' job.  The actual podman-autotest bits (also temporary) live upstream, as a branch to autotest-docker.  This PR just lays down most of the ground work, as there's still a lot of heavy-lifting needed to actually make the tests function.  That effort is happening in parallel, and therefor there will likely be further changes needed here, later.