### PR TITLE
Fix per-task become usage

### DIFF
--- a/exekutir/ansible.cfg
+++ b/exekutir/ansible.cfg
@@ -266,7 +266,7 @@ var_compression_level = 3
 #max_diff_size = 1048576
 
 [privilege_escalation]
-#become=True
+become=False
 #become_method=sudo
 #become_user=root
 become_user=root

--- a/kommandir/ansible.cfg
+++ b/kommandir/ansible.cfg
@@ -266,7 +266,7 @@ var_compression_level = 3
 #max_diff_size = 1048576
 
 [privilege_escalation]
-#become=True
+become=False
 #become_method=sudo
 #become_user=root
 become_user=root

--- a/kommandir/bin/adept_openstack.py
+++ b/kommandir/bin/adept_openstack.py
@@ -127,7 +127,6 @@ host_uuid: {uuid}
 host_name: {name}
 ansible_user: root
 ansible_ssh_user: root
-ansible_become: False
 ansible_connection: ssh
 """
 

--- a/test_openstack.py
+++ b/test_openstack.py
@@ -372,7 +372,7 @@ class TestDiscoverCreateDestroyBase(TestCaseBase):
                 written = write_call[0][0]
                 break
         self.assertIsNotNone(written)
-        for token in ('---', 'host_name', 'ansible_ssh_host', 'ansible_ssh_user', 'ansible_become', 'ansible_connection'):
+        for token in ('---', 'host_name', 'ansible_ssh_host', 'ansible_ssh_user', 'ansible_connection'):
             self.assertIn(token, written)
         for value in (name, ip_address):
             self.assertIn(value, written)


### PR DESCRIPTION
Ansible allows specifying become/become_user on a per-task basis, but
only if it's not overriden by a connection variable.  Unf. this is
exactly what's done by default in ``kommandir/bin/adept_openstack.py``.
Remove this behavior, and instead rely on the default settings in
ansible.conf.  This allows plays/tasks to override them when/as needed.

Signed-off-by: Chris Evich <cevich@redhat.com>