### PR TITLE
Don't preserve test-kommandir VMs in OpenStack

### DIFF
--- a/exekutir/inventory/group_vars/openstack.yml
+++ b/exekutir/inventory/group_vars/openstack.yml
@@ -33,7 +33,7 @@ cloud_provisioning_command:
     command: >
         {{ hostvars.exekutir.kommandir_workspace }}/bin/openstack_discover_create.py \
             {{ "--verbose" if adept_debug == True else "" }} \
-            --preserve -1 \
+            {{ "--preserve=-1" if kommandir_name_prefix in empty else "" }} \
             {{ "--lockdir=" ~ global_lockdir if global_lockdir|default() not in empty else ""}} \
             {{ "--userdata=" ~ hostvars.exekutir.workspace ~ "/roles/kommandir_discovered/files/kommandir_userdata.yml" }} \
             {{ kommandir_name }} \


### PR DESCRIPTION
These are always identified by having a non-empty kommandir_name_prefix.
When that variable is empty, set the preservation flag to indefinate.

Signed-off-by: Chris Evich <cevich@redhat.com>