### PR TITLE
A few fixes + Move GitHub role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,14 @@ language: python
 python:
     - "2.7"
 
+sudo: false
+
 branches:
     only:
         - master
-        - devel
-        - simplify
-
-sudo: false
-
-matrix:
-    fast_finish: true
-
-git:
-    submodules: false
 
 env:
     global:
-        - TYPOS="komandir executir ecoh roel fixup! squash! FIXME id_rsa <<<<<<< ======= >>>>>>>"
         - PATH="$PATH:$VIRTUAL_ENV/bin"
 
 install:
@@ -28,11 +19,11 @@ install:
 
 script:
     # Helps debugging
-    - export
+    - env | sort
+    # Check for typos
+    - ./.travis_typo_check.sh
     # Test building docs
     - cd docs && SPHINXOPTS="-W" make html
     - cd ..
     - ./venv-cmd.sh unit2 -vfc
     - ./venv-cmd.sh ./test_exekutir_xn.sh
-    # Check for some typos / git commit problems (except in this file)
-    - for i in $TYPOS; do echo; echo "$i"; git log -p $TRAVIS_COMMIT_RANGE | grep -a -2 "$i"; test "$?" != "0" || exit 1; done

--- a/.travis_typo_check.sh
+++ b/.travis_typo_check.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+# Common typos, and other patterns to watch for. Dashes break up words so we
+# don't trigger on ourself; spaces are for readability. Both will be removed.
+TYPOS="e-c-o-h | r-o-e-l | FIX-ME | p-d-b-.set_trace | fix-up! | s-qua-sh!"
+TYPOS=$(echo "$TYPOS" | tr -d ' -')
+
+# Try to determine where we diverged from master, and use that as our
+# base for diffs.
+echo "Checking against master for conflict and whitespace problems:"
+git diff --check $( echo $TRAVIS_COMMIT_RANGE | cut -d . -f 1) # Silent unless problem detected
+
+git log -p $TRAVIS_COMMIT_RANGE -- . &> /tmp/commits_with_diffs
+LINES=$(wc -l </tmp/commits_with_diffs)
+if (( $LINES == 0 ))
+then
+    echo "FATAL: no changes found since ${ANCESTOR}"
+    exit 3
+fi
+
+# The TYPOS value was formerly specified in .travis.yml
+# TODO: Remove this workaround in another/later PR
+sed -i -r -e '/^-        - TYPOS=/d' /tmp/commits_with_diffs
+
+echo "Examining $LINES change lines for typos:"
+egrep -a -i -2 --color=always "$TYPOS" /tmp/commits_with_diffs && exit 3
+
+exit 0

--- a/docs/source/definitions.inc.rst
+++ b/docs/source/definitions.inc.rst
@@ -19,7 +19,7 @@ Basic Definitions
 ``setup``, ``run``, and ``cleanup``
                                      The three context labels currently
                                      used in ADEPT.  Operationally,
-                                     the *run* context is dependent (to some degree)
+                                     the *run* context is dependent
                                      on a successful *setup* transition.  However,
                                      the *cleanup* context transition does not
                                      depend on success or failure of either

--- a/docs/source/hacking.inc.rst
+++ b/docs/source/hacking.inc.rst
@@ -83,11 +83,13 @@ to include ``nocloud``.  If required, also enable
 
 .. _repeat_contexts:
 
-Avoid repeating any context transition more than once, against the same
-workspace or manually running Ansible.  Either can be done if needed,
-but require some manual manipulations of files in the workspace.
-It's safer to apply the ``cleanup`` context, then start over again
-with ``setup`` against a fresh workspace, with a fresh `uuid`_
+For reglar/automated use, avoid repeating any context transition more
+than once, against the same workspace or manually running Ansible.
+However, for development/debugging purposes, depending on the job-specifics,
+most contexts may be re-applied (within reason).  Doing this may require
+manual manipulation of the `uuid`_ unless existing VMs are to be re-used.
+Otherwise, it's safest to apply the ``cleanup`` context, then start over again
+with ``setup`` against a fresh workspace, with a fresh `uuid`_.
 
 OpenStack Cloud
 ------------------

--- a/docs/source/introduction.inc.rst
+++ b/docs/source/introduction.inc.rst
@@ -3,19 +3,22 @@
 Introduction
 =============
 
-Both Autotest_ and `Docker Autotest`_ represent excellent and comprehensive testing
-frameworks. However, they are lacking in modern system configuration and orchestration
-capabilities. Especially, those required for Continuous Integration testing systems.
+ADEPT provides the ground-work for managing and executing tests against
+systems through multiple Ansible playbooks.  It supports the industry-standard
+practice of utilizing a separate triggering/scheduling versus execution host.
+Jobs may be defined in-repo or externally, and use the standard Ansible
+directory structure.  Jobs may define their own playbooks, roles,
+and scripts or re-use any of the content provided.
 
-This project aims to bridge those gaps, supporting any available cloud provisioning,
-or management system.  Along with a highly configurable, Ansible-based system
-configuration, test execution, and artifact collection.  While not tightly
-bound to `Docker Autotest`_, it is the default framework employed.
+Systems management, be it local or cloud, is extremely flexible.  Though
+an OpenStack setup is the default, any custom host-management tooling
+may be used.  Changing and maintaining management tooling is very smooth
+since the interface is simple and well defined.  No persistent systems or
+data-stores are required, though both may be utilized.
 
-Finally, since entry-point capabilities often unknown and fixed, ADEPT has
-very low initial dependency and resource requirements.  The included ``adept.py``
-program, along with a simple YAML input file directives, guides the entire whole
-operation.
-
-.. _autotest: http://autotest.github.io/
-.. _`docker autotest`: https://github.com/autotest/autotest-docker
+Finally, since initiator-host capabilities are often unknown and fixed,
+ADEPT has very low dependency and resource requirements.  The included
+``adept.py`` program, along with a simple YAML input file directives,
+bootstraps Ansible operations for every job.  While Ansible and it's
+dependencies are gathered at runtime, and confined within a python
+virtual environment.

--- a/docs/source/reference.inc.rst
+++ b/docs/source/reference.inc.rst
@@ -1,8 +1,6 @@
 Helpful References / docs.
 ---------------------------------
 
-*  `Autotest Documentation`_
-*  `Docker Autotest Documentation`_
 *  `Ansible doc. on splitting up host/group variables`_
 *  `Ansible doc. on magic variables`_
 *  `Ansible doc. on variable scoping`_
@@ -12,7 +10,5 @@ Helpful References / docs.
 .. _`Ansible doc. on splitting up host/group variables`: http://docs.ansible.com/ansible/intro_inventory.html#splitting-out-host-and-group-specific-data
 .. _`Ansible doc. on magic variables`: http://docs.ansible.com/ansible/playbooks_variables.html#magic-variables-and-how-to-access-information-about-other-hosts
 .. _`Ansible doc. on variable scoping`: http://docs.ansible.com/ansible/playbooks_variables.html#variable-scopes
-.. _`Autotest documentation`: http://autotest.readthedocs.org/en/latest/
-.. _`Docker Autotest documentation`: http://docker-autotest.readthedocs.org/en/latest/
 .. _`OpenStack client configuration documentation`: https://docs.OpenStack.org/developer/os-client-config/
 .. _`ReStructuredText quick reference`: http://docutils.sourceforge.net/docs/user/rst/quickref.html

--- a/exekutir/roles/common/tasks/main.yml
+++ b/exekutir/roles/common/tasks/main.yml
@@ -45,6 +45,7 @@
   set_fact:
     workspace_rsync_excludes:
         - "--exclude=.ssh"
+        - "--exclude=ssh"
         - "--exclude=.ansible"
         - "--exclude=.??*.lock"
         - "--exclude=.*cache"

--- a/exekutir/roles/exekutir_workspace_setup/tasks/main.yml
+++ b/exekutir/roles/exekutir_workspace_setup/tasks/main.yml
@@ -196,7 +196,7 @@
     dest: "{{ workspace }}/cache"
     force: True  # kommandir_workspace_setup will create it
     state: link
-  when: not (workspace ~ "/cache") | is_dir
+  when: not (workspace ~ "/cache" | is_dir)
 
 - name: Kommandir doesn't appear in it's inventory hosts files to workaround ansible bug
   replace:
@@ -234,17 +234,7 @@
     ansible_private_key_file: >
         {{ '"{{' }} kommandir_workspace {{ '}}' }}/ssh/kommandir_key {{ '"' }}
 
-- name: This and future kommandir's are protected by clobbering existing ssh directory
-  file:
-    dest: "{{ kommandir_workspace }}/ssh"
-    state: absent
-
-- name: The dot-ssh directory is absent
-  file:
-    path: "{{ kommandir_workspace }}/.ssh"
-    state: absent
-
-- name: A new ssh directory is present for kommandir's workspace
+- name: A ssh directory is present for kommandir's workspace
   file:
     dest: "{{ kommandir_workspace }}/ssh"
     state: directory
@@ -255,28 +245,19 @@
     src: "{{ kommandir_workspace }}/ssh"
     state: link
 
-- name: Future kommandirs and peons protected by new kommandir ssh private key
+- name: Future kommandirs and peons protected by new ssh key
   command: ssh-keygen -f "{{ kommandir_workspace }}/ssh/kommandir_key" -N ""
   args:
-    creates: "{{ kommandir_workspace }}/ssh/kommandir_key.pub"
-    chdir: "{{ kommandir_workspace }}/ssh"
+    creates: "{{ kommandir_workspace }}/ssh/kommandir_key*"
 
-- name: Exekutir's public key contents are buffered
-  set_fact:
-    result: '{{ lookup("file", ansible_private_key_file ~ ".pub") }}'
-
-- name: Exekutir's sync. source ssh/authorized_keys allows Exekutir's public key
-  lineinfile:
-    dest: "{{ kommandir_workspace }}/ssh/authorized_keys"
-    line: '{{ result }}'
-    create: True
-    state: present
-
-- name: Kommandir's ssh directory contains exekutir's public key
+- name: Kommandir's ssh directory contains exekutir's public key and is authorized
   copy:
-    dest: "{{ kommandir_workspace }}/ssh/exekutir_key.pub"
-    # Meh, it's already buffered, why type the name again
-    content: '{{ result }}'
+    src: "{{ workspace }}/ssh/exekutir_key.pub"
+    dest: "{{ kommandir_workspace }}/ssh/{{ item }}"
+    mode: "0600"
+  with_items:
+    - "exekutir_key.pub"
+    - "authorized_keys"
 
 - name: Mandatory job documentation template is rendered into results dir
   template:

--- a/exekutir/roles/kommandir_workspace_update/tasks/main.yml
+++ b/exekutir/roles/kommandir_workspace_update/tasks/main.yml
@@ -96,31 +96,6 @@
     mode: "0700"
     state: directory
 
-- name: Kommandir's workspace/cache is a directory
-  file:
-    path: "{{ kommandir_workspace }}/cache"
-    follow: True
-    state: directory
-  register: result
-
-- name: Kommandir's cache content checked out from git when directory created
-  git:
-    repo: "{{ item.repo }}"
-    dest: "{{ kommandir_workspace }}/cache/{{ item.cachepath }}"
-    # Shallow clone is much faster when specific branch/tag/version is _not_ used.
-    # Otherwise, if a version is specified, then the full history-depth is likely
-    # required to find it.
-    depth: "{{ omit if item.version is defined else item.depth | default(2) }}"
-    # HEAD is the default if not specified
-    version: "{{ item.version | default(omit) }}"
-    recursive: "{{ item.recursive | default(False) }}"
-    clone: "{{ item.clone | default(omit) }}"
-    refspec: "{{ item.refspec | default(omit) }}"
-    force: "{{ item.force | default(omit) }}"
-  when: result | changed and
-        git_cache_args is defined and git_cache_args not in [None,"",[],{}]
-  with_items: '{{ git_cache_args }}'
-
 - name: Remote Kommandir's workspace files have correct ownership
   command: "chown -R {{ uuid }}.{{ uuid }} {{ kommandir_workspace }}"
   when: "'nocloud' not in group_names"
@@ -141,4 +116,3 @@
   debug:
     var: result
   when: adept_debug
-

--- a/exekutir/roles/yumrepos/tasks/main.yml
+++ b/exekutir/roles/yumrepos/tasks/main.yml
@@ -33,6 +33,7 @@
     baseurl: "{{ item.baseurl }}"
     description: "Ansible added {{ item.name }} repo"
     gpgcheck: "{{ item.gpgcheck | default(True) }}"
+    gpgkey: "{{ item.gpgkey | default(omit) }}"
     exclude: "{{ item.excludepkgs | default(omit) }}"
     includepkgs: "{{ item.includepkgs | default(omit) }}"
     metadata_expire: 900  # quarter-hour

--- a/jobs/basic/install-autotest.yml
+++ b/jobs/basic/install-autotest.yml
@@ -1,8 +1,11 @@
 ---
 
 - hosts: peons
+  vars_files:
+      - kommandir_vars.yml
   roles:
     - autotest_installed
     - has_swap
     - docker_configured
     - docker_running
+    - success_peon_result

--- a/jobs/basic/kommandir_vars.yml
+++ b/jobs/basic/kommandir_vars.yml
@@ -1,0 +1,14 @@
+---
+
+git_cache_args:
+    - repo: "https://github.com/autotest/autotest.git"
+      recursive: False
+      depth: 3
+      cachepath: 'autotest'
+    - repo: "https://github.com/autotest/autotest-docker.git"
+      recursive: False
+      cachepath: 'autotest-docker'
+    - repo: "https://github.com/python-bugzilla/python-bugzilla.git"
+      recursive: False
+      cachepath: "python-bugzilla"
+      version: "v1.2.2"

--- a/jobs/basic/roles/autotest_executed/meta/main.yml
+++ b/jobs/basic/roles/autotest_executed/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+    - role: failed_peon_result
+      this_role: "autotest_executed"

--- a/jobs/basic/roles/autotest_installed/meta/main.yml
+++ b/jobs/basic/roles/autotest_installed/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+    - role: failed_peon_result
+      this_role: "autotest_installed"

--- a/jobs/basic/run.yml
+++ b/jobs/basic/run.yml
@@ -12,3 +12,6 @@
       - kommandir_vars.yml
   roles:
     - autotest_executed
+    - role: success_peon_result
+      vars:
+        results_template_filepath: adept_result_success.txt.j2

--- a/jobs/basic/setup.yml
+++ b/jobs/basic/setup.yml
@@ -1,5 +1,6 @@
 ---
 
+- include: kommandir_setup.yml
 - include: peon_creation.yml
 - include: peon_setup.yml
 - include: install-autotest.yml

--- a/kommandir/kommandir_setup.yml
+++ b/kommandir/kommandir_setup.yml
@@ -1,0 +1,13 @@
+---
+
+# N/B: This file can be overwritten by a copy from job_path.
+
+# Required for peons to be grouped
+- hosts: kommandir
+  vars_files:
+      - kommandir_vars.yml
+  roles:
+    - common
+    - ansible_versioned
+    - compatible_ansible
+    - git_repos_cached

--- a/kommandir/peon_creation.yml
+++ b/kommandir/peon_creation.yml
@@ -2,15 +2,6 @@
 
 # N/B: This file can be overwritten by a copy from job_path.
 
-# Required for peons to be grouped
-- hosts: kommandir
-  vars_files:
-      - kommandir_vars.yml
-  roles:
-    - common
-    - ansible_versioned
-    - compatible_ansible
-
 - hosts: peons
   # Inventory is incomplete
   gather_facts: False

--- a/kommandir/peon_setup.yml
+++ b/kommandir/peon_setup.yml
@@ -2,7 +2,6 @@
 
 # N/B: This file can be overwritten by a copy from job_path.
 
-
 - hosts: peons
   strategy: linear  # The add_host module can only be run using linear strategy
   vars_files:

--- a/kommandir/roles/git_repos_cached/defaults/main.yml
+++ b/kommandir/roles/git_repos_cached/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+
+# Maximum time to wait (in seconds) for each git operation to complete
+git_op_timeout: '{{ 60 * 30 }}'
+
+# Interval time (in seconds) to wait between each git status check
+git_op_status_delay: '10'
+
+# List of dictionaries, with options to the git ansible module.
+# However, instead of `dest`, specify cache-dir relative path in `cachepath`
+git_cache_args: {}
+
+# When true, always force-clone, clobbering any posible local changes.
+always_force: False

--- a/kommandir/roles/git_repos_cached/meta/main.yml
+++ b/kommandir/roles/git_repos_cached/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+    - role: failed_peon_result
+      this_role: "git_repos_cached"

--- a/kommandir/roles/git_repos_cached/tasks/async_git.yml
+++ b/kommandir/roles/git_repos_cached/tasks/async_git.yml
@@ -1,0 +1,27 @@
+---
+
+- name: The destination directory always exists
+  file:
+    path: "{{ workspace }}/cache/{{ git_op.cachepath }}"
+    state: directory
+
+- name: git_op's options are fed to git module
+  git:
+    dest: "{{ workspace }}/cache/{{ git_op.cachepath }}"
+    repo: "{{ git_op.repo }}"
+    depth: "{{ git_op.depth | default(omit) }}"
+    recursive: "{{ git_op['recursive'] | default(omit) }}"
+    reference: "{{ git_op.reference | default(omit) }}"
+    refspec: "{{ git_op.refspec | default(omit) }}"
+    remote: "{{ git_op.remote | default(omit) }}"
+    version: "{{ git_op.version | default(omit) }}"
+    force: "{{ git_op.force | default(omit) if not always_force else True }}"
+  # Async-tasks always show changed.  Turn that off and evaluate it later.
+  changed_when: False
+  register: result
+  async: "{{ git_op_timeout }}"
+  poll: 0
+
+- name: git_op async-state is included in async_results list
+  set_fact:
+    async_results: "{{ async_results | union([result | combine(git_op)]) }}"

--- a/kommandir/roles/git_repos_cached/tasks/async_status.yml
+++ b/kommandir/roles/git_repos_cached/tasks/async_status.yml
@@ -1,0 +1,12 @@
+---
+
+- name: All async states in async_result completed or timed out
+  async_status:
+    jid: "{{ async_result.ansible_job_id }}"
+  failed_when: result | failed
+  changed_when: result | changed
+  register: result
+  until: result.finished | bool
+  # Guarantee at least one retry
+  retries: "{{ (git_op_timeout|int / git_op_status_delay|int) | round(method='ceil')|int }}"
+  delay: "{{ git_op_status_delay|int }}"

--- a/kommandir/roles/git_repos_cached/tasks/main.yml
+++ b/kommandir/roles/git_repos_cached/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+
+- name: Temporary facts are initialized
+  set_fact:
+    result:
+    async_results: []
+
+- assert:
+    that:
+        - "inventory_hostname == 'kommandir'"
+        # Verify conformance with defaults, expected types, and values
+        - "git_op_timeout | default(0) >= 1"
+        - "git_op_status_delay | default(0) >= 1"
+        - "git_cache_args is defined"
+
+- name: Kommandir's workspace/cache is a directory
+  file:
+    path: "{{ workspace }}/cache"
+    follow: True
+    state: directory
+  register: mkdir_cache
+
+- name: Initialize kommandir's cache dir from git
+  block:
+
+    - name: All git operations are run in parallel
+      include_tasks: "{{ role_path }}/tasks/async_git.yml"
+      with_items: "{{ git_cache_args }}"
+      loop_control:
+        loop_var: "git_op"
+
+    - name: All parallel git operations are completed and successful
+      include_tasks: "{{ role_path }}/tasks/async_status.yml"
+      with_items: "{{ async_results }}"
+      loop_control:
+        loop_var: "async_result"
+
+  when: mkdir_cache | changed

--- a/kommandir/roles/git_repos_cached/vars/main.yml
+++ b/kommandir/roles/git_repos_cached/vars/main.yml
@@ -1,0 +1,4 @@
+---
+
+async_results: []
+result:

--- a/kommandir/roles/success_peon_result/defaults/main.yml
+++ b/kommandir/roles/success_peon_result/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+# Full path to template indicating a successful result for this host
+success_template_filepath: "{{ playbook_dir }}/roles/success_peon_result/templates/adept_result.txt.j2"

--- a/kommandir/roles/success_peon_result/meta/main.yml
+++ b/kommandir/roles/success_peon_result/meta/main.yml
@@ -1,0 +1,5 @@
+---
+
+dependencies:
+    - role: failed_peon_result
+      this_role: "success_peon_result"

--- a/kommandir/roles/success_peon_result/tasks/main.yml
+++ b/kommandir/roles/success_peon_result/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+- include_role:
+    name: failed_peon_result
+    allow_duplicates: True
+  vars:
+    results_template_filepath: '{{ success_template_filepath }}'

--- a/kommandir/roles/success_peon_result/templates/adept_result.txt.j2
+++ b/kommandir/roles/success_peon_result/templates/adept_result.txt.j2
@@ -1,0 +1,2 @@
+The ADEPT {{ adept_context }} context successfully completed for {{ job_name }}
+on the {{ inventory_hostname }} peon.

--- a/kommandir/setup.yml
+++ b/kommandir/setup.yml
@@ -2,5 +2,6 @@
 
 # N/B: This file can be overwritten by a copy from job_path.
 
+- include: kommandir_setup.yml
 - include: peon_creation.yml
 - include: peon_setup.yml


### PR DESCRIPTION
* Support re-applying all plays in the *setup* context to support easier job-development and debugging.
* Support use of a gpgkey URI in custom yumrepo configurations.
* Add a 'success' role, overwriting the result file produced by ``failed_peon_result`` role-dependency.
* Move git-based kommandir-cache initialization into kommandir role for more flexibility.