### PR TITLE
Increase default timeout for podman job

### DIFF
--- a/jobs/podman_basic/roles/autotest_executed/defaults/main.yml
+++ b/jobs/podman_basic/roles/autotest_executed/defaults/main.yml
@@ -3,7 +3,7 @@
 # Name for results sub-directory
 podman_autotest_tag: default
 
-podman_autotest_timeout: 30  # minutes
+podman_autotest_timeout: 120  # minutes
 
 # When non-empty, e-mail address to send report to
 notification_email:


### PR DESCRIPTION
I remember Ed mentioning this job takes 40-something minutes.  Fix the
default timeout to exceed that by a healthy margin.  Giving it lots
of breathing room is fine, since generally nobody is sitting around
waiting on an automated job.  I don't believe there are any shorter
timeouts in higher (execution) layers this will collide with.

Signed-off-by: Chris Evich <cevich@redhat.com>