### PR TITLE
VerboseFilter() : handle non-string log messages

### DIFF
--- a/kommandir/bin/adept_openstack.py
+++ b/kommandir/bin/adept_openstack.py
@@ -158,9 +158,11 @@ class VerboseFilter(logging.Filter):
         self.verbose = verbose
 
     def filter(self, record):
-        # Always strip leading '>', no matter what level we're at
-        if record.msg.startswith('>'):
-            record.msg = record.msg.lstrip('>').lstrip()
+        # record.msg may not be string; use getMessage to guarantee string form
+        msg = record.getMessage()
+        if msg.startswith('>'):
+            # Always remove leading '>'; this overrides the record string
+            record.msg = msg.lstrip('>').lstrip()
             # When logging at INFO level (default), allow these only if verbose
             if self.level == logging.INFO and record.levelno == self.level:
                 return self.verbose

--- a/test_verbosefilter.py
+++ b/test_verbosefilter.py
@@ -39,7 +39,7 @@ class TestVerboseFilter(TestCase):
         self.logger = logging.getLogger()
         self.message_list = []
 
-    def _test_basic(self, level, verbose, expect):
+    def _test_init(self, level, verbose):
         # Grrr. The Logger thing is a global, and there doesn't seem to be
         # a way to get a new one each time. For addHandler() and addFilter()
         # to work, we need to delve into internals.
@@ -51,6 +51,9 @@ class TestVerboseFilter(TestCase):
         self.message_list = []
         self.logger.addHandler(MyHandler(self.message_list))
         self.logger.addFilter(self.a_o.VerboseFilter(level, verbose))
+
+    def _test_basic(self, level, verbose, expect):
+        self._test_init(level, verbose)
 
         # Always log the same messages...     pylint: disable=C0326
         logging.debug( "this is DEBUG")
@@ -66,6 +69,18 @@ class TestVerboseFilter(TestCase):
                 expect_list.append('this is {}'.format(level_name))
 
         self.assertEqual(self.message_list, expect_list)
+
+    def test_exception(self):
+        """
+        logger can be invoked with non-string messages; make sure our
+        filter doesn't choke on those.
+        """
+        self._test_init(logging.DEBUG, False)
+
+        import exceptions
+        exception_arg = exceptions.IndexError
+        logging.error(exception_arg)
+        self.assertEqual(self.message_list, [exception_arg])
 
 def test_generator(test_info):
     """


### PR DESCRIPTION
It looks like the logger can be called with a non-string
object as a message; this resulted today in a failure
in VerboseFilter:

    if record.msg.startswith('>'):
  AttributeError: 'exceptions.IndexError' object has no attribute 'startswith'

Solution: use getMessage() instead of directly accessing
the .msg element; that should reliably give us a string.

Add test.

Signed-off-by: Ed Santiago <santiago@redhat.com>