### PR TITLE
VerboseFilter: handle format strings

### DIFF
--- a/kommandir/bin/adept_openstack.py
+++ b/kommandir/bin/adept_openstack.py
@@ -158,9 +158,9 @@ class VerboseFilter(logging.Filter):
         self.verbose = verbose
 
     def filter(self, record):
-        # record.msg may not be string; use getMessage to guarantee string form
-        msg = record.getMessage()
-        if msg.startswith('>'):
+        # record.msg may not be string, but '>' processing requires one
+        msg = record.msg
+        if isinstance(msg, str) and msg.startswith('>'):
             # Always remove leading '>'; this overrides the record string
             record.msg = msg.lstrip('>').lstrip()
             # When logging at INFO level (default), allow these only if verbose

--- a/test_verbosefilter.py
+++ b/test_verbosefilter.py
@@ -23,7 +23,7 @@ class MyHandler(logging.Handler):
         self.message_list = message_list
 
     def emit(self, record):
-        self.message_list.append(record.msg)
+        self.message_list.append(record.getMessage())
 
 
 class TestVerboseFilter(TestCase):
@@ -80,7 +80,20 @@ class TestVerboseFilter(TestCase):
         import exceptions
         exception_arg = exceptions.IndexError
         logging.error(exception_arg)
-        self.assertEqual(self.message_list, [exception_arg])
+        self.assertEqual(self.message_list, [str(exception_arg)])
+
+    def test_reformatting(self):
+        """
+        2018-07-10 fixes issue seen by cevich in production: if message
+        is a format string (with percent sign), and includes further
+        arguments, an earlier version of our filter would crash
+        with 'not all arguments converted' because we replaced
+        the format string with the *formatted* one. This subtest
+        fails under that earlier revision.
+        """
+        self._test_init(logging.DEBUG, True)
+        logging.info(">string with %s", "extra args")
+        self.assertEqual(self.message_list, ["string with extra args"])
 
 def test_generator(test_info):
     """


### PR DESCRIPTION
The last "fix" to VerboseFilter was broken: it would
replace a string like ("this is a %s", "test") with
("this is a test", "test") which would then yield:

    TypeError: not all arguments converted during string processing

Solution: don't replace the logging string. To handle
the previous issue (logger getting called with Exceptions),
in VerboseFilter, simply ignore non-string messages

Signed-off-by: Ed Santiago <santiago@redhat.com>