### PR TITLE
Bump RHEL 'latest' image names to 7.6

### DIFF
--- a/jobs/basic/inventory/hosts.yml
+++ b/jobs/basic/inventory/hosts.yml
@@ -29,16 +29,20 @@ all:
                 # OpenStack *-latest images include 'compose.repo', use that.
                 disable_all_rh_repos: True  # subscription-manager repos
                 # 'compose.repo' doesn't include extras, use the latest
-                yum_repos: '{{ [_private_latest_extras_yum_repo]
-                               if _private_latest_extras_yum_repo is defined
-                               else [] }}'
-
-                enable_repos:  # These and only these, already cooked into image
-                    - base
-                    - optional
+                yum_repos:
+                    - '{{ _private_latest_base_yum_repo | default({}) }}'
+                    - '{{ _private_latest_optional_yum_repo | default({}) }}'
+                    - '{{ _private_latest_extras_yum_repo | default({}) }}'
+                enable_repos:
+                    - '{{ "base"
+                          if _private_latest_base_yum_repo is defined
+                          else "" }}'  # can't use `omit` here.
+                    - '{{ "optional"
+                          if _private_latest_optional_yum_repo is defined
+                          else "" }}'
                     - '{{ "latest-extras"
                           if _private_latest_extras_yum_repo is defined
-                          else "optional" }}'  # can't use `omit` here.
+                          else "" }}'
 
                 # Low-level rpms to install
                 install_rpms:

--- a/jobs/podman_basic/inventory/hosts.yml
+++ b/jobs/podman_basic/inventory/hosts.yml
@@ -19,20 +19,25 @@ all:
                 rhsm: {}
                 disable_all_rh_repos: True  # subscription-manager repos
                 yum_repos:
+                    - '{{ _private_latest_base_yum_repo | default({}) }}'
+                    - '{{ _private_latest_optional_yum_repo | default({}) }}'
                     - '{{ _private_latest_extras_yum_repo | default({}) }}'
                     - name: "baude-Upstream_CRIO_Family"
                       description: "Copr repo for Upstream_CRIO_Family owned by baude"
                       baseurl: "https://copr-be.cloud.fedoraproject.org/results/baude/Upstream_CRIO_Family/epel-7-x86_64/"
                       gpgkey: "https://copr-be.cloud.fedoraproject.org/results/baude/Upstream_CRIO_Family/pubkey.gpg"
                       gpgcheck: True
-
                 enable_repos:
-                    - base
-                    - optional
+                    - baude-Upstream_CRIO_Family
+                    - '{{ "base"
+                          if _private_latest_base_yum_repo is defined
+                          else "" }}'  # can't use `omit` here.
+                    - '{{ "optional"
+                          if _private_latest_optional_yum_repo is defined
+                          else "" }}'
                     - '{{ "latest-extras"
                           if _private_latest_extras_yum_repo is defined
-                          else "optional" }}'  # can't use `omit` here.
-                    - baude-Upstream_CRIO_Family
+                          else "" }}'
                 install_rpms:
                     - bridge-utils
                     - bzip2

--- a/kommandir/inventory/group_vars/openstack/peon_images.yml
+++ b/kommandir/inventory/group_vars/openstack/peon_images.yml
@@ -12,7 +12,7 @@ peon_image: >
   {%- elif inventory_hostname|search("rhel7-3-latest") -%}rhel-7.3-server-x86_64-latest
   {%- elif inventory_hostname|search("rhel7-4-latest") -%}rhel-7.4-server-x86_64-latest
   {%- elif inventory_hostname|search("rhel7-5-latest") -%}rhel-7.5-server-x86_64-latest
-  {%- elif inventory_hostname|search("rhel-latest") -%}rhel-7.5-server-x86_64-latest
+  {%- elif inventory_hostname|search("rhel-latest") -%}rhel-7.6-server-x86_64-nightly
   {#- RHEL Atomic Host Images -#}\
   {%- elif inventory_hostname|search("rhelatomic7-2") -%}rhel-atomic-cloud-7.2-released-latest
   {%- elif inventory_hostname|search("rhelatomic7-3") -%}rhel-atomic-cloud-7.3-released-latest


### PR DESCRIPTION
Signed-off-by: Chris Evich <cevich@redhat.com>